### PR TITLE
envelope: Fix tags without a value

### DIFF
--- a/ircreactor/envelope.py
+++ b/ircreactor/envelope.py
@@ -51,8 +51,11 @@ class RFC1459Message(object):
             tags = {}
 
             for tag in tag_str:
-                k, v = tag.split('=', 1)
-                tags[k] = v
+                if '=' in tag:
+                    k, v = tag.split('=', 1)
+                    tags[k] = v
+                else:
+                    tags[tag] = True
 
         source = None
         if s[0].startswith(':'):


### PR DESCRIPTION
Tag strings like `@c;a=b` fail because the first tag doesn't have an equals sign in it, so the splitting doesn't work. This fixes that sort of error.

Would we want to default to `True` for tags without values, or set it to empty string to keep all the values as strings only?
