### PR TITLE
envelope: ignore multiple spaces separating atoms as per 1459

### DIFF
--- a/ircreactor/envelope.py
+++ b/ircreactor/envelope.py
@@ -60,16 +60,20 @@ class RFC1459Message(object):
             s = s[1:]
 
         verb = s[0].upper()
-        params = s[1:]
+        original_params = s[1:]
+        params = []
 
-        for param in params:
-            if param.startswith(':'):
-                idx = params.index(param)
-                arg = ' '.join(params[idx:])
-                arg = arg[1:]
-                params = params[:idx]
+        while len(original_params):
+            # skip multiple spaces in middle of message, as per 1459
+            if original_params[0] == '' and len(original_params) > 1:
+                original_params.pop(0)
+                continue
+            elif original_params[0].startswith(':'):
+                arg = ' '.join(original_params)[1:]
                 params.append(arg)
                 break
+            else:
+                params.append(original_params.pop(0))
 
         return cls.from_data(verb, params, source, tags)
 


### PR DESCRIPTION
This makes a line like this:  `":src test  ab    cd"` decode as `['src', 'test', 'ab', 'cd']`, as per RFC1459 allowing multiple spaces separating atoms.

Had to split it into two lists, otherwise the code would've depended on modifying the list while iterating over it, which is a bad idea.
